### PR TITLE
modify end as 0-based

### DIFF
--- a/code/data_preprocessing/phenotype/gene_annotation.ipynb
+++ b/code/data_preprocessing/phenotype/gene_annotation.ipynb
@@ -488,7 +488,7 @@
     "                \n",
     "                # Update min start and max end\n",
     "                start_pos = int(row[3]) - 1  # Convert to 0-based for BED\n",
-    "                end_pos = int(row[4])\n",
+    "                end_pos = int(row[4]) - 1  # Both start and end are used\n",
     "                data['start'] = min(data['start'], start_pos)\n",
     "                data['end'] = max(data['end'], end_pos)\n",
     "        \n",


### PR DESCRIPTION
1. I think we don't need to handle [start, end] differently for different strands, reasons are articulated [here](https://github.com/rl3328/xqtl-analysis/discussions/37). For those with prior knowledge, please refer directly to section 3. Start and End and the following sections.
2. I found a small typo that end position is not converted to 0-based coordiate system.