### PR TITLE
documentation updates for phenotype imputation and some mnm steps

### DIFF
--- a/code/data_preprocessing/phenotype/phenotype_imputation.ipynb
+++ b/code/data_preprocessing/phenotype/phenotype_imputation.ipynb
@@ -96,8 +96,8 @@
    "outputs": [],
    "source": [
     "sos run pipeline/phenotype_imputation.ipynb gEBMF \\\n",
-    "    --phenoFile output/rnaseq/bulk_rnaseq_tmp_matrix.low_expression_filtered.outlier_removed.tmm.expression.bed.bed.gz \\\n",
-    "    --cwd output/phenotype \\\n",
+    "    --phenoFile data/protocol_example.protein.bed.gz \\\n",
+    "    --cwd output/phenotype/impute_gebmf \\\n",
     "    --no-qc-prior-to-impute "
    ]
   },

--- a/code/data_preprocessing/phenotype_preprocessing.ipynb
+++ b/code/data_preprocessing/phenotype_preprocessing.ipynb
@@ -102,8 +102,8 @@
    "outputs": [],
    "source": [
     "sos run pipeline/phenotype_imputation.ipynb gEBMF \\\n",
-    "    --phenoFile output/rnaseq/bulk_rnaseq_tmp_matrix.low_expression_filtered.outlier_removed.tmm.expression.bed.bed.gz \\\n",
-    "    --cwd output/phenotype \\\n",
+    "    --phenoFile data/protocol_example.protein.bed.gz \\\n",
+    "    --cwd output/phenotype/impute_gebmf \\\n",
     "    --no-qc-prior-to-impute "
    ]
   },

--- a/code/mnm_analysis/mnm_methods/rss_analysis.ipynb
+++ b/code/mnm_analysis/mnm_methods/rss_analysis.ipynb
@@ -159,11 +159,16 @@
    },
    "outputs": [],
    "source": [
-    "sos run xqtl-protocol/pipeline/rss_analysis.ipynb univariate_rss \\\n",
-    "    --ld-meta-data ADSP_R4_EUR.LD.list \\\n",
-    "    --gwas-meta-data AD_sumstat_list.txt \\\n",
-    "    --impute --qc-method dentist --finemapping-method susie_rss \\\n",
-    "    --diagnostics"
+    "sos run pipeline/rss_analysis.ipynb univariate_rss \\\n",
+    "    --ld-meta-data data/ld_meta_file_with_bim.tsv \\\n",
+    "    --gwas-meta-data data/mnm_regression/gwas_meta_data.txt \\\n",
+    "    --qc_method \"rss_qc\" --impute \\\n",
+    "    --finemapping_method \"susie_rss\" \\\n",
+    "    --cwd output/rss_analysis \\\n",
+    "    --skip_analysis_pip_cutoff 0 \\\n",
+    "    --skip_regions 6:25000000-35000000 \\\n",
+    "    --region_name 22:49355984-50799822\n",
+    "    "
    ]
   },
   {

--- a/code/mnm_analysis/mnm_miniprotocol.ipynb
+++ b/code/mnm_analysis/mnm_miniprotocol.ipynb
@@ -181,12 +181,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sos run $PATH/rss_analysis.ipynb univariate_rss \\\n",
-    "--ld-meta-data $PATH/ldref/ld_meta_file.tsv \\\n",
-    "    --gwas-meta-data $PATH/GWAS_sumstat_meta_cloud_Apr_9.tsv \\\n",
+    "sos run pipeline/rss_analysis.ipynb univariate_rss \\\n",
+    "    --ld-meta-data data/ld_meta_file_with_bim.tsv \\\n",
+    "    --gwas-meta-data data/mnm_regression/gwas_meta_data.txt \\\n",
     "    --qc_method \"rss_qc\" --impute \\\n",
     "    --finemapping_method \"susie_rss\" \\\n",
-    "    --cwd $PATH/output/ \\\n",
+    "    --cwd output/rss_analysis \\\n",
     "    --skip_analysis_pip_cutoff 0 \\\n",
     "    --skip_regions 6:25000000-35000000 \\\n",
     "    --region_name 22:49355984-50799822"

--- a/code/pecotmr_integration/SuSiE_enloc.ipynb
+++ b/code/pecotmr_integration/SuSiE_enloc.ipynb
@@ -207,25 +207,35 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3163f151-96be-46c5-b52e-dbc2ff5f3fe5",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "Include the `--skip-enrich` to skip the enrichment part. Otherwise, the `*enrichment.rds` file from the previous step must be in the location of the `--cwd` directory. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c51e5221-0cb6-4f83-bd2d-10897bb54dd6",
    "metadata": {
     "kernel": "SoS"
    },
    "source": [
     "```bash\n",
-    " sos run SuSiE_enloc.ipynb susie_coloc    \\\n",
-    "    --gwas_meta_data  /mnt/vast/hpc/csg/rf2872/Work/Multivariate/susie_2024_new/demo_gwas/demo_gwas.block_results_db.tsv    \\\n",
-    "    --xqtl_meta_data  /mnt/vast/hpc/csg/rf2872/Work/Multivariate/susie_2024_new/demo_overlap/demo_overlap.overlapped.gwas.tsv   \\\n",
-    "    --xqtl_finemapping_obj preset_variants_result susie_result_trimmed              \\\n",
-    "    --xqtl_varname_obj preset_variants_result variant_names             \\\n",
-    "    --gwas_finemapping_obj AD_Bellenguez_2022 RSS_QC_RAISS_imputed susie_result_trimmed              \\\n",
-    "    --gwas_varname_obj  AD_Bellenguez_2022 RSS_QC_RAISS_imputed variant_names             \\\n",
-    "    --xqtl_region_obj  region_info   grange       \\\n",
-    "    --qtl-path /mnt/vast/hpc/homes/rf2872/aws/rds_files    \\\n",
-    "    --gwas_path /home/hs3393/RSS_QC/GWAS_finemapping_Apr9/univariate_rss    \\\n",
-    "    --context_meta /mnt/vast/hpc/homes/rf2872/codes/xqtl-analysis/resource/context_meta.tsv      \\\n",
-    "    --ld_meta_file_path /mnt/vast/hpc/csg/data_public/20240120_ADSP_LD_matrix/ld_meta_file.tsv \\\n",
-    "    --cwd demo_coloc\n",
+    "sos run pipeline/SuSiE_enloc.ipynb susie_coloc \\\n",
+    "    --gwas-meta-data data/susie_enloc_data/demo_gwas.block_results_db.tsv \\\n",
+    "    --xqtl-meta-data data/susie_enloc_data/demo_overlap.overlapped.gwas.tsv \\\n",
+    "    --xqtl_finemapping_obj preset_variants_result susie_result_trimmed \\\n",
+    "    --xqtl_varname_obj preset_variants_result variant_names \\\n",
+    "    --gwas_finemapping_obj AD_Bellenguez_2022 RSS_QC_RAISS_imputed susie_result_trimmed \\\n",
+    "    --gwas_varname_obj  AD_Bellenguez_2022 RSS_QC_RAISS_imputed variant_names \\\n",
+    "    --xqtl_region_obj  region_info grange \\\n",
+    "    --qtl-path data/susie_enloc_data \\\n",
+    "    --gwas_path data/susie_enloc_data \\\n",
+    "    --context_meta data/susie_enloc_data/context_meta.tsv \\\n",
+    "    --ld_meta_file_path /restricted/projectnb/xqtl/xqtl_protocol/scripts/pixi_scripts/ld_meta_file.tsv \\\n",
+    "    --cwd output/susie_coloc\n",
     "```"
    ]
   },
@@ -237,9 +247,25 @@
    },
    "source": [
     "```\n",
-    "\n",
+    "INFO: Running get_overlapped_analysis_regions: get overlapped regions from flatten table, to get the regions with overlapped variants and select those regions for coloc analysis\n",
+    "INFO: get_overlapped_analysis_regions is completed.\n",
+    "INFO: get_overlapped_analysis_regions output:   overlapped_regional_data\n",
+    "INFO: Running susie_coloc: \n",
+    "INFO: susie_coloc is completed.\n",
+    "INFO: susie_coloc output:   /restricted/projectnb/xqtl/xqtl_protocol/toy_xqtl_protocol/output/susie_coloc/susie_coloc/demo_overlap.overlapped.demo_gwas.Knight_eQTL_brain@ENSG00000142798.coloc.rds\n",
+    "INFO: Workflow susie_coloc (ID=w1fbe3c73c7bfc0b7) is executed successfully with 2 completed steps.\n",
     "```"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a3beed94-6fd6-4653-9e9a-d827c4522bb0",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
rna_calling.ipynb star_align - done. Multiple tool name and output file name changes. Also had to add “—chimSegmentMin 0” to toy example to get around Picard error involving paired end reads aligning to different chromosomes

rna_calling.ipynb rnaseq_call - done. added in the gtex code to get around “squeeze” argument. Now use the “squeeze” pandas function. 

Leafcutter - todo Leafcutter2, Ru

vcf_qc.ipynb qc - done. added a “skip_vcf_header_filtering” global argument to skip any filters involving vcf info (DP, AD, etc)

phenotype_imputation.ipynb gEBMF - done

tensorqtl.ipynb trans - errors related to column types ** Xuewei and Yifei **

mnm_regression.ipynb mnm_genes - todo Anqi

mnm_regression.ipynb fsusie - done

mnm_regression.ipynb mnm - done

rss_analysis.ipynb univariate_rss - done

susie_encloc.ipynb susie_coloc - done

twas_ctwas.ipynb twas - troubleshooting errors Chunming

twas_ctwas.ipynb ctwas - troubleshooting errors Chunming