### PR TITLE
minor documentation updates for TransorQTL trans toy example

### DIFF
--- a/code/association_scan/TensorQTL/TensorQTL.ipynb
+++ b/code/association_scan/TensorQTL/TensorQTL.ipynb
@@ -69,7 +69,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "kernel": "SoS"
@@ -82,9 +81,10 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "kernel": "SoS"
+   },
    "source": [
     "For trans-analysis:\n",
     "\n",
@@ -300,9 +300,7 @@
     "kernel": "SoS"
    },
    "source": [
-    "### ii. Trans TensorQTL Command \n",
-    "\n",
-    "Note: Some protein is not in the customized cis windows list. There we will need to remove them from the analysis by create a region_list. Noted that the region list need to be a actual file. So `<()` file is not acceptable. "
+    "### ii. Trans TensorQTL Command \n"
    ]
   },
   {
@@ -316,33 +314,14 @@
    },
    "outputs": [],
    "source": [
-    "zcat output/protocol_example.protein.bed.gz | cut -f 1,2,3,4 | grep -v -e ENSG00000163554 \\\n",
-    "    -e ENSG00000171564 -e ENSG00000171560 -e ENSG00000171557 > output/protocol_example.protein.region_list"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "kernel": "SoS",
-    "vscode": {
-     "languageId": "plaintext"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "sos run xqtl-protocol/pipeline/TensorQTL.ipynb trans \\\n",
-    "    --genotype-file output/genotype_by_chrom/protocol_example.genotype.chr21_22.genotype_by_chrom_files.txt \\\n",
-    "    --phenotype-file  output/phenotype_by_chrom/protocol_example.protein.bed.phenotype_by_chrom_files.region_list.txt \\\n",
-    "    --region-list output/protocol_example.protein.region_list \\\n",
-    "    --covariate-file output/protocol_example.protein.protocol_example.samples.protocol_example.genotype.chr21_22.pQTL.unrelated.plink_qc.prune.pca.Marchenko_PC.gz \\\n",
-    "    --customized-cis-windows input/protocol_example.protein.enhanced_cis_chr21_chr22.bed \\\n",
-    "    --chromosome 22 \\\n",
-    "    --no-permutation \\\n",
-    "    --covariate-pattern msex age_death pheno_PC \\\n",
-    "    --qvalue-cutoff 0.01 \\\n",
-    "    --cwd output/association/trans/ \\\n",
-    "    --MAC 5"
+    "sos run pipeline/TensorQTL.ipynb trans \\\n",
+    "    --genotype-file data/wgs.merged.plink_qc.genotype_trans_files.txt \\\n",
+    "    --phenotype-file output/phenotype/phenotype_by_chrom_for_trans/bulk_rnaseq.phenotype_by_chrom_files.txt \\\n",
+    "    --region-list data/combined_AD_genes.csv \\\n",
+    "    --region-list-phenotype-column 4 \\\n",
+    "    --covariate-file output/covariate/bulk_rnaseq_tmp_matrix.low_expression_filtered.outlier_removed.tmm.expression.covariates.wgs.merged.plink_qc.plink_qc.prune.pca.Marchenko_PC.gz \\\n",
+    "    --cwd output/tensorqtl_trans/ \\\n",
+    "    --MAC 5 "
    ]
   },
   {

--- a/code/association_scan/qtl_association_testing.ipynb
+++ b/code/association_scan/qtl_association_testing.ipynb
@@ -114,15 +114,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sos run xqtl-protocol/pipeline/TensorQTL.ipynb trans \\\n",
-    "    --genotype-file output/protocol_example.genotype.chr21_22.genotype_by_chrom_files.txt \\\n",
-    "    --phenotype-file output/phenotype_by_chrom/protocol_example.protein.bed.phenotype_by_chrom_files.txt \\\n",
-    "    --region-list output/phenotype/protocol_example.protein.region_list \\\n",
-    "    --covariate-file output/protocol_example.protein.protocol_example.samples.protocol_example.genotype.chr21_22.pQTL.unrelated.plink_qc.prune.pca.Marchenko_PC.gz \\\n",
-    "    --customized-cis-windows xqtl_association/protocol_example.protein.enhanced_cis_chr21_chr22.bed \\\n",
-    "    --cwd output/trans_association/ \\\n",
-    "    --MAC 5 --numThreads 2 -J 22 \\\n",
-    "    --container oras://ghcr.io/statfungen/tensorqtl_apptainer:latest"
+    "sos run pipeline/TensorQTL.ipynb trans \\\n",
+    "    --genotype-file data/wgs.merged.plink_qc.genotype_trans_files.txt \\\n",
+    "    --phenotype-file output/phenotype/phenotype_by_chrom_for_trans/bulk_rnaseq.phenotype_by_chrom_files.txt \\\n",
+    "    --region-list data/combined_AD_genes.csv \\\n",
+    "    --region-list-phenotype-column 4 \\\n",
+    "    --covariate-file output/covariate/bulk_rnaseq_tmp_matrix.low_expression_filtered.outlier_removed.tmm.expression.covariates.wgs.merged.plink_qc.plink_qc.prune.pca.Marchenko_PC.gz \\\n",
+    "    --cwd output/tensorqtl_trans/ \\\n",
+    "    --MAC 5 "
    ]
   },
   {


### PR DESCRIPTION
rna_calling.ipynb star_align - done. Multiple tool name and output file name changes. Also had to add “—chimSegmentMin 0” to toy example to get around Picard error involving paired end reads aligning to different chromosomes

rna_calling.ipynb rnaseq_call - done. added in the gtex code to get around “squeeze” argument. Now use the “squeeze” pandas function. 

Leafcutter - todo Leafcutter2, Ru

vcf_qc.ipynb qc - done. added a “skip_vcf_header_filtering” global argument to skip any filters involving vcf info (DP, AD, etc)

phenotype_imputation.ipynb gEBMF - done

tensorqtl.ipynb trans - done

mnm_regression.ipynb mnm_genes - todo Anqi

mnm_regression.ipynb fsusie - done

mnm_regression.ipynb mnm - done

rss_analysis.ipynb univariate_rss - done

susie_encloc.ipynb susie_coloc - done

twas_ctwas.ipynb twas - troubleshooting errors Chunming

twas_ctwas.ipynb ctwas - troubleshooting errors Chunming