### PR TITLE
modification on qtl_association_postprocessing.ipynb

### DIFF
--- a/code/association_scan/qtl_association_postprocessing.ipynb
+++ b/code/association_scan/qtl_association_postprocessing.ipynb
@@ -143,7 +143,7 @@
     "    --maf-cutoff 0.01 --cis-window 1000000 \\\n",
     "    --regional-pattern \"*.cis_qtl.regional.tsv.gz$\" \\\n",
     "    --output-dir output/heirarchical_multi_test/output \\\n",
-    "    --archive-dir output/heirarchical_multi_test/archive \\\n",
+    "    --archive-dir output/heirarchical_multi_test/archive --enable_archive True \\\n",
     "    -s force\n",
     "```\n"
    ]
@@ -191,7 +191,7 @@
     "    --regional-pattern \"*.cis_qtl_top_assoc.txt.gz$\" \\\n",
     "    --pvalue-pattern \"pvalue_.*_interaction\" \\\n",
     "    --qvalue-pattern \"qvalue_interaction\" \\\n",
-    "    --output-dir ~/output --archive-dir ~/archive -s force \\\n",
+    "    --output-dir ~/output --archive-dir ~/archive -s force --enable_archive True \\\n",
     "    --fdr-threshold 0.3 # set it large for illustration purpose\n",
     "```"
    ]
@@ -232,7 +232,7 @@
     "    --pecotmr-path /path/to/pecotmr \\\n",
     "    --af-col maf --tss-dist-col feature_tss --tes-dist-col feature_tes \\\n",
     "    --qvalue-pattern \"^qvalue$\" \\\n",
-    "    --output-dir ~/output --archive-dir ~/archive -s force\n",
+    "    --output-dir ~/output --archive-dir ~/archive --enable_archive True -s force\n",
     "```"
    ]
   },
@@ -358,6 +358,8 @@
     "parameter: regional_pattern = \"NULL\"\n",
     "parameter: qtl_pattern = \"*.cis_qtl.pairs.tsv.gz$\"\n",
     "parameter: n_variants_suffix = \"cis_n_variants_stats.tsv.gz\"\n",
+    "parameter: enable_archive = False\n",
+    "parameter: additional_pvalue_cols = \"\"\n",
     "\n",
     "work_dir = f\"{cwd:a}/{sub_dir}\"\n",
     "if sub_dir == path(\".\"):\n",
@@ -401,6 +403,14 @@
     "    params$end_distance_col   <- \"${tes_dist_col}\"\n",
     "    params$af_col <- \"${af_col}\"\n",
     "    params$molecular_id_col <- \"${molecular_id_col}\"\n",
+    "    enable_archive_val <- \"${enable_archive}\"\n",
+    "    if (enable_archive_val %in% c(\"True\", \"TRUE\", \"true\")) {\n",
+    "      params$enable_archive <- TRUE\n",
+    "    } else {\n",
+    "      params$enable_archive <- FALSE\n",
+    "    }\n",
+    "    message(sprintf(\"Archive setting - input: '%s', converted: %s\", enable_archive_val, params$enable_archive))    \n",
+    "    params$additional_pvalue_cols <- \"${additional_pvalue_cols}\"    \n",
     "    convert_null_strings <- function(params) {\n",
     "      if (is.list(params)) {\n",
     "        # Apply the function to each element in the list\n",
@@ -420,7 +430,9 @@
     "    source(\"${pecotmr_path}/inst/code/tensorqtl_postprocessor.R\")\n",
     "    results <- hierarchical_multiple_testing_correction(params)\n",
     "    write_results(results, params$output_dir, params$workdir, to_cwd = \"regional\")\n",
-    "    archive_files(params)\n",
+    "    if (params$enable_archive) {\n",
+    "      archive_files(params)\n",
+    "    }\n",
     "    saveRDS(results, ${_output:r})"
    ]
   }


### PR DESCRIPTION
- Made archive optional
The --enable_archive flag now controls whether archiving is executed. Users can disable archiving as needed.

- Added --additional_pvalue_cols parameter
If this parameter is specified and the associated q-values are missing, q-values will now be computed for all provided p-value columns (not just the one defined by --pvalue-pattern).